### PR TITLE
http -> https

### DIFF
--- a/speed-changes.js
+++ b/speed-changes.js
@@ -1,5 +1,5 @@
 var environmentProd = true;
-var domain = ((environmentProd)? 'http://www.kapiticoast.govt.nz/' : 'http://uat.kapiticoast.govt.nz.testwin.gdmedia.tv/');
+var domain = ((environmentProd)? 'https://www.kapiticoast.govt.nz/' : 'http://uat.kapiticoast.govt.nz.testwin.gdmedia.tv/');
 
 var roads = 
 {


### PR DESCRIPTION
While attempting to find mixed content exceptions on https://www.kapiticoast.govt.nz/, as it is now forced https, [the page loading this Javascript](https://www.kapiticoast.govt.nz/Your-Council/Projects/speedlimits/) had a few warnings.

Although Chrome currently accepts http images in https pages, [this may not be true for much longer](https://techcrunch.com/2018/02/08/chrome-will-soon-mark-all-unencrypted-pages-as-not-secure/). It may very well be a good idea to change the domain to its https counterpart as 25 images loaded by this script are http.